### PR TITLE
Add --prefix option in arcus_cmd.py to dump prefix stats

### DIFF
--- a/arcus_cmd.py
+++ b/arcus_cmd.py
@@ -23,6 +23,8 @@ from __future__ import absolute_import
 import sys,os,socket,re
 
 from optparse import OptionParser
+from collections import OrderedDict
+
 import paramiko
 
 from arcus_util import zookeeper
@@ -66,6 +68,7 @@ if __name__ == '__main__':
 	parser.add_option('', '--all_node', dest='all_node', default=False, help='select all node', action='store_true')
 	parser.add_option('', '--all_server', dest='all_server', default=False, help='select all server', action='store_true')
 	parser.add_option('-t', '--timeout', dest='timeout', default='200', help='arcus command timeout (msec)')
+	parser.add_option('-p', '--prefix_stats', dest='prefix', help='show arcus prefix stats')
 
 	(options, args) = parser.parse_args()
 
@@ -368,3 +371,88 @@ if __name__ == '__main__':
 
 			script_fh.write(start_script)
 
+	if options.prefix:
+
+		def print_stats(prefix, stats, is_total=False):
+			result = ""
+			printed_count = 0
+			for current_prefix, prefix_stats in stats.items():
+				if prefix == 'all' or current_prefix.startswith(prefix) or (current_prefix=='<null>' and prefix=='null'):
+					printed_count += 1
+					heading = "PREFIX %-10s " % (current_prefix)
+					result += heading
+					for key, value in prefix_stats.items():
+						if key == 'time' and is_total:
+							continue
+						if key in ['tsz', 'lcs', 'scs', 'bcs', 'bps', 'pfs', 'gps']:
+							result += "\n" + " "*(len(heading))
+						if key in ['bps', 'pfs']:
+							result += " "*12
+						try:
+							result += "%s %7d "% (key, value)
+						except KeyError:
+							# Some version of arcus-memcached does not print 'inc' and 'dec'
+							pass
+					result += "\n"
+			if printed_count > 0:
+				print(result)
+			else:
+				print("(no result)")
+
+
+		def merge_stats(total_stats, node_stats):
+			for prefix, stats in node_stats.items():
+				if prefix not in total_stats:
+					total_stats[prefix] = OrderedDict()
+				for key, value in node_stats[prefix].items():
+					total_stats[prefix][key] = total_stats[prefix].get(key, 0) + value
+
+		def collect_stats(node, command):
+			"""
+			Returns:
+			{ 'prefix1': OrderedDict[('key1', value1), ('key2', value2)...], ... }
+			"""
+			try:
+				result = node.do_arcus_command(command, timeout)
+			except Exception as e:
+				print('%s\t\tFAILED!!' % (node))
+				print(e)
+				return {}
+
+			node_stats = {}
+
+			for line in result.splitlines():
+				if not line.startswith("PREFIX"):
+					continue
+
+				tokens = line.split()
+				current_prefix = tokens[1]
+
+				prefix_stats = OrderedDict()
+
+				for i in range(2, len(tokens), 2):
+					key = tokens[i]
+					value = int(tokens[i+1])
+					prefix_stats[key] = value
+
+				node_stats[current_prefix] = prefix_stats
+
+			return node_stats
+
+		prefixes_total = {}
+		detail_total = {}
+
+		for node in lists:
+			print(node)
+
+			node_stats = collect_stats(node, 'stats prefixes')
+			print_stats(options.prefix, node_stats)
+			merge_stats(prefixes_total, node_stats)
+
+			node_stats = collect_stats(node, 'stats detail dump')
+			print_stats(options.prefix, node_stats)
+			merge_stats(detail_total, node_stats)
+
+		print('[Total]')
+		print_stats(options.prefix, prefixes_total, is_total=True)
+		print_stats(options.prefix, detail_total, is_total=True)

--- a/arcus_util.py
+++ b/arcus_util.py
@@ -62,7 +62,7 @@ class arcus_node(object):
 		return '[%s:%s]' % (self.ip, self.port)
 
 	def do_arcus_command(self, command, timeout=0.2):
-		tn = telnetlib.Telnet(self.ip, self.port)
+		tn = telnetlib.Telnet(str(self.ip), int(self.port))
 		tn.write(command + '\r\n')
 
 		if command[0:5] == 'scrub' or command[0:5] == 'flush':


### PR DESCRIPTION
https://github.com/naver/kaist-oss-course/issues/51 이슈의 PR https://github.com/naver/arcus-python-client/pull/9 을 arcus-python2-client에도 똑같이 적용하여 보냅니다.

Centos 6.7및 Ubuntu 14.04환경에서 테스트한 결과, Python2.6, 2.7에서는 `do_arcus_command`함수에서 사용하는 `telnetlib.Telnet`의 인자가 unicode형식은 받지 못합니다.
따라서, `arcus_util.py`의 `do_arcus_command`함수 내에서 ip는 string으로, port는 int로 casting했습니다.
