### PR TITLE
eflag bit 연산관련해서..

### DIFF
--- a/test.py
+++ b/test.py
@@ -195,13 +195,7 @@ assert ret.get_result() == False
 #####################################################################################################
 def itoh(i):
 	h = hex(i)
-	if len(h) % 2 == 1:
-		h = '0x0%s' % h[2:].upper()
-	else:
-		h = '0x%s' % h[2:].upper()
-
-	return h
-	
+	return '0x'+('0'*(6-len(h)))+h[2:].upper()
 
 
 # int key


### PR DESCRIPTION
```python
for i in xrange(0, 200):
	ret = client.bop_insert('test:btree_eflag', i, i, itoh(i))
ret = client.bop_get('test:btree_eflag', (0, 200), EflagFilter('EFLAG & 0x00ff == 0x0001')) 
```
을 실행하였을 때, ('0x0001', 1)이 나오지 않습니다.

bit 연산을 할 때, 0x0000, 0x0010, 0x0ff0 이런식으로 0x뒤에 숫자 네개가 붙지 않으면 연산이 정확히 되지 않는 것을 확인하였고, itoh()함수를 커밋내용과 같이 바꾸었더니 제대로 동작합니다.


